### PR TITLE
Update vue.config.js

### DIFF
--- a/base/vue.config.js
+++ b/base/vue.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   outputDir: '../docs',
-  baseUrl: process.env.NODE_ENV === 'production' ? '/vant-demo/' : '/'
+  publicPath: process.env.NODE_ENV === 'production' ? '/vant-demo/' : '/'
 };

--- a/rem/vue.config.js
+++ b/rem/vue.config.js
@@ -3,7 +3,7 @@ const pxtorem = require('postcss-pxtorem');
 
 module.exports = {
   outputDir: 'docs',
-  baseUrl: process.env.NODE_ENV === 'production' ? '/vant-demo/' : '/',
+  publicPath: process.env.NODE_ENV === 'production' ? '/vant-demo/' : '/',
   css: {
     loaderOptions: {
       postcss: {

--- a/theme/vue.config.js
+++ b/theme/vue.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   outputDir: 'docs',
-  baseUrl: process.env.NODE_ENV === 'production' ? '/vant-demo/' : '/',
+  publicPath: process.env.NODE_ENV === 'production' ? '/vant-demo/' : '/',
   css: {
     loaderOptions: {
       less: {


### PR DESCRIPTION
WARN  "baseUrl" option in vue.config.js is deprecated now, please use "publicPath" instead.